### PR TITLE
fix kernel version of depmod command

### DIFF
--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -27,7 +27,7 @@
 %endif
 
 %define gdrdrv_install_script                                           \
-/sbin/depmod -a %{kernel_version} &> /dev/null ||:                      \
+/sbin/depmod -a %{kernel_version}%{?dist}.%{_arch} &> /dev/null ||:                      \
 %{MODPROBE} -rq gdrdrv||:                                               \
 %{MODPROBE} gdrdrv||:                                                   \
                                                                         \
@@ -289,10 +289,12 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 
 
 %changelog
+* Fri Dec 03 2021 Alex Domingo <alex.domingo.toro@vub.be> 2.3-0
+- Add suffixes to kernel version of depmod
 * Tue Nov 16 2021 Alex Domingo <alex.domingo.toro@vub.be> 2.3-0
 - Fix requires for gdrcopy-devel
-- Fix paths to kernel modules
 - Fix paths to package source file
+- Add suffixes to kernel version in old_driver_install_dir path
 - Disable (again) exes from gdrcopy to remove dependency on CUDA
 * Fri Jul 23 2021 Pak Markthub <pmarkthub@nvidia.com> %{GDR_VERSION}-%{_release}
 - Remove automatically-generated build id links.

--- a/packages/gdrcopy.spec
+++ b/packages/gdrcopy.spec
@@ -2,7 +2,7 @@
 %{!?CUDA: %define CUDA /usr/local/cuda}
 %{!?GDR_VERSION: %define GDR_VERSION 2.0}
 %{!?KVERSION: %define KVERSION %(uname -r)}
-%{!?MODULE_LOCATION: %define MODULE_LOCATION kernel/drivers/misc/}
+%{!?MODULE_LOCATION: %define MODULE_LOCATION /kernel/drivers/misc/}
 %{!?NVIDIA_DRIVER_VERSION: %define NVIDIA_DRIVER_VERSION UNKNOWN}
 %{!?NVIDIA_SRC_DIR: %define NVIDIA_SRC_DIR UNDEFINED}
 %{!?BUILD_KMOD: %define BUILD_KMOD 0}
@@ -17,7 +17,7 @@
 %define kmod_kernel_version %{KVERSION}
 
 %define kernel_version %{dkms_kernel_version}
-%define old_driver_install_dir /lib/modules/%{kernel_version}%{?dist}.%{_arch}/%{MODULE_LOCATION}
+%define old_driver_install_dir /lib/modules/%{kernel_version}/%{MODULE_LOCATION}
 
 # This is to set the dkms package name. For backward compatibility with the previous versions, we need to keep using "kmod".
 %global dkms kmod
@@ -27,7 +27,7 @@
 %endif
 
 %define gdrdrv_install_script                                           \
-/sbin/depmod -a %{kernel_version}%{?dist}.%{_arch} &> /dev/null ||:                      \
+/sbin/depmod -a %{kernel_version} &> /dev/null ||:                      \
 %{MODPROBE} -rq gdrdrv||:                                               \
 %{MODPROBE} gdrdrv||:                                                   \
                                                                         \
@@ -290,7 +290,7 @@ rm -rf $RPM_BUILD_DIR/%{name}-%{version}
 
 %changelog
 * Fri Dec 03 2021 Alex Domingo <alex.domingo.toro@vub.be> 2.3-0
-- Add suffixes to kernel version of depmod
+- Undo our customizations to the kernel version
 * Tue Nov 16 2021 Alex Domingo <alex.domingo.toro@vub.be> 2.3-0
 - Fix requires for gdrcopy-devel
 - Fix paths to package source file


### PR DESCRIPTION
This was already fixed but it was lost at some point during the sync with `470` from upstream.